### PR TITLE
Update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,12 @@ Herein lies the contribution guidelines for helping out with this project. Do ta
 * Tasks should run sequentially by vulnerability ID as listed in the given standard. 
 * Every task must be named and should adhere to the following convention:
 ```yml
-- name: "| $severity | $id_number | patch/audit |\n
-        $description_provided_by_standard"
+- name: "$severity | $id_number | PATCH/AUDIT | $description_provided_by_standard"
 
-- name: "| HIGH | V-38476 | PATCH |\n
-        Vendor-provided cryptographic certificates must be installed to verify the integrity of system software."
+- name: "HIGH | V-38476 | PATCH | Vendor-provided cryptographic certificates must be installed to verify the integrity of system software."
 ```
-* Every standard implemented must consist of at least two sequential tasks, one that conducts a check and registers it to a variable, and another that applies the standard. Note that the task which applies the standard does not necessarily have to use the registered variable from the prior task.
+* Every standard implemented must consist of at least two sequential tasks: one that conducts a check and registers the results to a variable, and another that applies the standard. Note that the task which applies the standard does not necessarily have to use the registered variable from the prior task.
+```
 * There should only be one standard remediated or checked per task (even at the expense of having less code)
 * All audit tasks should: 
     * have `changed_when: no`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Ansible Lockdown
 
 If you're reading this, hopefully you are considering helping out with the Lockdown project. 
 
-Herein lies the contribution guidelines for helping out with this project. Do take the guidlines here literally, if you find issue with any of them or you see room for improvement, please let us know via a GitHub issue or via the [Lockdown mailing list][mail].
+Herein lies the contribution guidelines for helping out with this project. Do take the guidelines here literally, if you find issue with any of them or you see room for improvement, please let us know via a GitHub issue or via the [Lockdown mailing list][mail].
 
 
 
@@ -48,7 +48,6 @@ Herein lies the contribution guidelines for helping out with this project. Do ta
       path: /tmp/deletethis
 
 # Not This
-# This
 - name: Create a directory
   file:
     state: directory
@@ -57,11 +56,30 @@ Herein lies the contribution guidelines for helping out with this project. Do ta
 
 * There should be a single line break between tasks
 * Every task (except prelim tasks) should have, at a minimum and when applicable, the following tags:
-   * Severity level (cat1, cat2, high, etc)
-   * Identification number (example, the vulnerabilty ID number in the case of RHEL6 STIG)
-   * audit/patch
-* Tags can be either bracketed or multi-line
-* Tasks should happen sequentially as they appear in the given standard. 
+    * Severity level (cat1, high, cat2, medium, etc.)
+    * Identification number (example, the vulnerability ID number in the case of RHEL6 STIG)
+    * audit/patch
+* Tags can be either bracketed or multi-line, though multi-line is preferred. If multi-line tags are used, they should be indented four spaces just like module arguments above.
+```yml
+# This
+- name: Create a directory
+  file:
+      state: directory
+      path: /tmp/deletethis
+  tags:
+      - files
+      - debug
+
+# Not This
+- name: Create a directory
+  file:
+    state: directory
+    path: /tmp/deletethis
+  tags:
+    - files
+    - debug
+```
+* Tasks should run sequentially by vulnerability ID as listed in the given standard. 
 * Every task must be named and should adhere to the following convention:
 ```yml
 - name: "| $severity | $id_number | patch/audit |\n

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,14 @@ Herein lies the contribution guidelines for helping out with this project. Do ta
 - name: "HIGH | V-38476 | PATCH | Vendor-provided cryptographic certificates must be installed to verify the integrity of system software."
 ```
 * Every standard implemented must consist of at least two sequential tasks: one that conducts a check and registers the results to a variable, and another that applies the standard. Note that the task which applies the standard does not necessarily have to use the registered variable from the prior task.
+* There should only be one standard remediated or checked per task, even if several remediations could be combined into a single task. The goal of this role is granular remediation.
+* If multiple standards must be combined into a single task, the name should adhere to the following convention:
+```yml
+- name: "MEDIUM | V-38443, V-38448, V-38449 | AUDIT |\n
+        \tThe /etc/gshadow file must be owned by root.\n
+        \tThe /etc/gshadow file must be group-owned by root.\n
+        \tThe /etc/gshadow file must have mode 0000."
 ```
-* There should only be one standard remediated or checked per task (even at the expense of having less code)
 * All audit tasks should: 
     * have `changed_when: no`
     * have `always_run: yes`


### PR DESCRIPTION
Updated guidance on naming tasks and improved some of the language and formatting in certain sections.

The third commit in the PR regarding formatting task that _must_ remediate multiple is up for debate. I played around with this quite a bit and, while it's a bit ugly in the code and it does break syntax highlighting, the printed output is nice when using `\t` and `\n`. I think this format is acceptable if used sparingly.

``` shell
TASK: [rhel6stig | MEDIUM | V-38443, V-38448, V-38449 | AUDIT |
    The /etc/gshadow file must be owned by root.
    The /etc/gshadow file must be group-owned by root.
    The /etc/gshadow file must have mode 0000.] ***
```

I'm wondering if for tasks that have multiple remediations, the ID number should be placed in front of the description, or if this is redundant and unhelpful.

``` shell
TASK: [rhel6stig | MEDIUM | V-38443, V-38448, V-38449 | AUDIT |
    V-38443 The /etc/gshadow file must be owned by root.
    V-38448 The /etc/gshadow file must be group-owned by root.
    V-38449 The /etc/gshadow file must have mode 0000.] ***
```

Open to input on this.
