### PR TITLE
Ansible playbooks for deploying Ubuntu 14.04 CIS Benchmarks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "RHEL7-STIG"]
 	path = RHEL7-STIG
 	url = https://github.com/MindPointGroup/RHEL7-STIG.git
+[submodule "cis-ubuntu-14-ansible"]
+	path = cis-ubuntu-14-ansible
+	url = https://github.com/oguya/cis-ubuntu-14-ansible.git


### PR DESCRIPTION
This sub-module contains ansible playbooks for deploying CIS Security Benchmarks on hosts running Ubuntu 14.04.

https://github.com/oguya/cis-ubuntu-14-ansible